### PR TITLE
Make an @Entity's generated getter use its field's docComment

### DIFF
--- a/src/main/java/nl/kii/entity/processors/EntityProcessor.xtend
+++ b/src/main/java/nl/kii/entity/processors/EntityProcessor.xtend
@@ -250,7 +250,7 @@ class EntityProcessor implements TransformationParticipant<MutableClassDeclarati
 
 				cls.addMethod('get' + f.simpleName.toFirstUpper) [
 					docComment = '''
-						Get the value of the «cls.simpleName» entity property «f.simpleName».
+						«IF f.docComment.defined»«f.docComment»«ELSE»Get the value of the «cls.simpleName» entity property «f.simpleName».«ENDIF»
 						@return the found «f.simpleName» or null if not set.
 					'''
 					primarySourceElement = f


### PR DESCRIPTION
The documentation added to the entity's variables will now get propagated to the getter. 
